### PR TITLE
Adds semantic highlighting, and operator expressions

### DIFF
--- a/dist/Panda.json
+++ b/dist/Panda.json
@@ -43,6 +43,12 @@
       }
     },
     {
+      "scope": "keyword.operator.expression",
+      "settings": {
+        "foreground": "#FFB86C"
+      }
+    },
+    {
       "scope": "storage",
       "settings": {
         "foreground": "#FFB86C"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 	"categories": [
 		"Themes"
 	],
+	"semanticHighlighting": true,
 	"icon": "assets/panda.png",
 	"homepage": "https://github.com/tinkertrain/panda-syntax-vscode",
 	"galleryBanner": {

--- a/themes/panda-base.yaml
+++ b/themes/panda-base.yaml
@@ -40,6 +40,10 @@ tokenColors:
   settings:
     foreground: _pink
 
+- scope: keyword.operator.expression
+  settings:
+    foreground: _orange
+
 # -----------------------------------------------------------------------------
 # Storage
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
This enables colors on Object Expressions to address [this issue from the other repo](https://github.com/tinkertrain/panda-syntax-vscode/issues/42), and enables `semanticHighlighting` to address [this issue.](https://github.com/tinkertrain/panda-syntax-vscode/issues/31)

@siamak FYI - Since this repo is a fork, I don't believe Issues are enabled by default. Any chance we could get those enabled?

Before:

<img width="1840" alt="CleanShot 2022-07-25 at 08 00 23@2x" src="https://user-images.githubusercontent.com/39167186/180783237-36f26458-d46c-427e-8c80-df5687354dc7.png">

After:

<img width="1840" alt="CleanShot 2022-07-25 at 08 01 27@2x" src="https://user-images.githubusercontent.com/39167186/180783434-c07fa386-a7fe-4fb7-b073-1df35b4d9ed0.png">
